### PR TITLE
Remove reference to RFC 7282

### DIFF
--- a/draft-ietf-procon-2418bis.md
+++ b/draft-ietf-procon-2418bis.md
@@ -595,10 +595,8 @@ working group shall prevail.  (However, it must be noted that
 "dominance" is not to be determined on the basis of volume or
 persistence, but rather a more general sense of agreement.) Consensus
 can be determined by a show of hands, humming, or any other means on
-which the WG agrees (by rough consensus). Note that {{?RFC7282}}
-provides some examples that help describe the nuances of consensus in
-the IETF. It is up to the Chair to determine if rough consensus has
-been reached.
+which the WG agrees (by rough consensus). It is up to the Chair to
+determine if rough consensus has been reached.
 
 It can be particularly challenging to gauge the level of consensus on
 a mailing list.  There are two different cases where a working group


### PR DESCRIPTION
This reference was added in #44 and we found out later that it did not have consensus, so we're backing it out.

Fixes #56